### PR TITLE
Fix the iris.csv file

### DIFF
--- a/Iris/csv/iris.csv
+++ b/Iris/csv/iris.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:95d1aa7231958ecc4d417abb5954defc8e31149478f66fba956c13b418a82901
-size 4611
+oid sha256:281600342ed35a0eff640343a956a5ebfdaedbc7c2312a95343c8ba9c52030d5
+size 4610


### PR DESCRIPTION
Remove a blank line from the end of the iris.csv file - this blank line actually causes the code in the TensorFlow doc to error out.

The blank line didn't previously cause this - I believe the new CSV parser reads the empty line as an empty row in the table, which then messes things up.  Either way, the empty line shouldn't be there.