### PR TITLE
Fix taxi.parquet file

### DIFF
--- a/Taxi/parquet/taxi.parquet
+++ b/Taxi/parquet/taxi.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:74712fd972130ecfadbf4e5b0eb3ffc295ca0965dc6c7d5c3dafd9724d79570f
-size 239829
+oid sha256:7e7910b904e7a2ce0b4fca4e1f7cc688a30d77eb6a2421f98f26108567d8b108
+size 344265


### PR DESCRIPTION
This fixes the file to use correct timestamps, so it can now be read into Deephaven via our Parquet reader.